### PR TITLE
Enhancement: Implement FrontMatter::hasFrontMatter()

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,29 @@ This project can be installed via Composer:
 Usage
 -----
 
+Parse an arbitrary `string`
+===========================
+
 ```php
+<?php
+
 $frontMatter = new Webuni\FrontMatter\FrontMatter();
 
 $document = $frontMatter->parse($str);
 
 $data = $document->getData();
 $content = $document->getContent();
+```
+
+Test if a `string` has front matter
+====================================================
+
+```php
+<?php
+
+$frontMatter = new Webuni\FrontMatter\FrontMatter();
+
+$hasFrontMatter = $frontMatter->hasFrontMatter($str);
 ```
 
 Alternatives

--- a/src/FrontMatter.php
+++ b/src/FrontMatter.php
@@ -81,4 +81,9 @@ final class FrontMatter implements FrontMatterInterface
 
         return sprintf("%s\n%s\n%s\n%s", $this->startSep, $data, $this->endSep, $document->getContent());
     }
+
+    public function hasFrontMatter(string $source): bool
+    {
+        return preg_match($this->regexp, $source) === 1;
+    }
 }

--- a/src/FrontMatterInterface.php
+++ b/src/FrontMatterInterface.php
@@ -34,4 +34,13 @@ interface FrontMatterInterface
      * @return string
      */
     public function dump(Document $document): string;
+
+    /**
+     * Returns true when source has front matter defined that can be parsed by the specific implementation.
+     *
+     * @param string $source The source
+     *
+     * @return bool
+     */
+    public function hasFrontMatter(string $source): bool;
 }

--- a/tests/FrontMatterTest.php
+++ b/tests/FrontMatterTest.php
@@ -25,72 +25,78 @@ class FrontMatterTest extends TestCase
     /**
      * @dataProvider getYaml
      */
-    public function testYaml($string, $data, $content)
+    public function testYaml($string, $data, $content, bool $hasFrontMatter)
     {
         $frontMatter = new FrontMatter();
         $document = $frontMatter->parse($string);
 
         $this->assertDocument($data, $content, $document);
         $this->assertEquals($string, $frontMatter->dump($document));
+        $this->assertSame($hasFrontMatter, $frontMatter->hasFrontMatter($string));
     }
 
     /**
      * @dataProvider getSeparator
      */
-    public function testYamlWithCustomSeparator($string, $data, $content)
+    public function testYamlWithCustomSeparator($string, $data, $content, bool $hasFrontMatter)
     {
         $frontMatter = new FrontMatter(null, '<!--', '-->');
         $document = $frontMatter->parse($string);
 
         $this->assertDocument($data, $content, $document);
         $this->assertEquals($string, $frontMatter->dump($document));
+        $this->assertSame($hasFrontMatter, $frontMatter->hasFrontMatter($string));
     }
 
     /**
      * @dataProvider getJson
      */
-    public function testJson($string, $data, $content)
+    public function testJson($string, $data, $content, bool $hasFrontMatter)
     {
         $frontMatter = new FrontMatter(new JsonProcessor());
         $document = $frontMatter->parse($string);
 
         $this->assertDocument($data, $content, $document);
         $this->assertEquals($string, $frontMatter->dump($document));
+        $this->assertSame($hasFrontMatter, $frontMatter->hasFrontMatter($string));
     }
 
     /**
      * @dataProvider getPlainJson
      */
-    public function testPlainJson($string, $data, $content)
+    public function testPlainJson($string, $data, $content, bool $hasFrontMatter)
     {
         $frontMatter = new FrontMatter(new JsonWithoutBracesProcessor(), '{', '}');
         $document = $frontMatter->parse($string);
 
         $this->assertDocument($data, $content, $document);
         $this->assertEquals($string, $frontMatter->dump($document));
+        $this->assertSame($hasFrontMatter, $frontMatter->hasFrontMatter($string));
     }
 
     /**
      * @dataProvider getYaml
      */
-    public function testNeon($string, $data, $content)
+    public function testNeon($string, $data, $content, bool $hasFrontMatter)
     {
         $frontMatter = new FrontMatter(new NeonProcessor());
         $document = $frontMatter->parse($string);
 
         $this->assertDocument($data, $content, $document);
         $this->assertEquals($string, $frontMatter->dump($document));
+        $this->assertSame($hasFrontMatter, $frontMatter->hasFrontMatter($string));
     }
 
     /**
      * @dataProvider getToml
      */
-    public function testToml($string, $data, $content)
+    public function testToml($string, $data, $content, bool $hasFrontMatter)
     {
         $frontMatter = new FrontMatter(new TomlProcessor());
         $document = $frontMatter->parse($string);
 
         $this->assertDocument($data, $content, $document);
+        $this->assertSame($hasFrontMatter, $frontMatter->hasFrontMatter($string));
 
         $this->expectException(\BadMethodCallException::class);
         $this->expectExceptionMessage('Dump for Toml is not implemented.');
@@ -101,45 +107,45 @@ class FrontMatterTest extends TestCase
     public function getYaml()
     {
         return [
-            ['foo', [], 'foo'],
-            ["---\nfoo: bar\n---\n", ['foo' => 'bar'], ''],
-            ["---\nfoo: bar\n---\ntext", ['foo' => 'bar'], 'text'],
+            ['foo', [], 'foo', false],
+            ["---\nfoo: bar\n---\n", ['foo' => 'bar'], '', true],
+            ["---\nfoo: bar\n---\ntext", ['foo' => 'bar'], 'text', true],
         ];
     }
 
     public function getSeparator()
     {
         return [
-            ['foo', [], 'foo'],
-            ["<!--\nfoo: bar\n-->\n", ['foo' => 'bar'], ''],
-            ["<!--\nfoo: bar\n-->\ntext", ['foo' => 'bar'], 'text'],
+            ['foo', [], 'foo', false],
+            ["<!--\nfoo: bar\n-->\n", ['foo' => 'bar'], '', true],
+            ["<!--\nfoo: bar\n-->\ntext", ['foo' => 'bar'], 'text', true],
         ];
     }
 
     public function getJson()
     {
         return [
-            ['foo', [], 'foo'],
-            ["---\n{\"foo\":\"bar\"}\n---\n", ['foo' => 'bar'], ''],
-            ["---\n{\"foo\":\"bar\"}\n---\ntext", ['foo' => 'bar'], 'text'],
+            ['foo', [], 'foo', false],
+            ["---\n{\"foo\":\"bar\"}\n---\n", ['foo' => 'bar'], '', true],
+            ["---\n{\"foo\":\"bar\"}\n---\ntext", ['foo' => 'bar'], 'text', true],
         ];
     }
 
     public function getPlainJson()
     {
         return [
-            ['foo', [], 'foo'],
-            ["{\n\"foo\":\"bar\"\n}\n", ['foo' => 'bar'], ''],
-            ["{\n\"foo\":\"bar\"\n}\ntext", ['foo' => 'bar'], 'text'],
+            ['foo', [], 'foo', false],
+            ["{\n\"foo\":\"bar\"\n}\n", ['foo' => 'bar'], '', true],
+            ["{\n\"foo\":\"bar\"\n}\ntext", ['foo' => 'bar'], 'text', true],
         ];
     }
 
     public function getToml()
     {
         return [
-            ['foo', [], 'foo'],
-            ["---\nfoo = 'bar'\n---\n", ['foo' => 'bar'], ''],
-            ["---\nfoo = 'bar'\n---\ntext", ['foo' => 'bar'], 'text'],
+            ['foo', [], 'foo', false],
+            ["---\nfoo = 'bar'\n---\n", ['foo' => 'bar'], '', true],
+            ["---\nfoo = 'bar'\n---\ntext", ['foo' => 'bar'], 'text', true],
         ];
     }
 


### PR DESCRIPTION
This PR

* [x] implements `FrontMatter::hasFrontMatter()`

💁‍♂️ As of the moment, `FrontMatter::parse()` always returns a `Document`, even when a `string` does not have any front matter. By exposing `FrontMatter::hasFrontMatter()`, we can verify if a `string` has front matter defined. This can be useful for finding files in a directory, but ignoring those that do not have front matter defined.
