### PR TITLE
Fixed PHP 8.4 deprecations

### DIFF
--- a/src/FrontMatter.php
+++ b/src/FrontMatter.php
@@ -39,7 +39,7 @@ final class FrontMatter implements FrontMatterInterface
         return new self(new JsonWithoutBracesProcessor(), '{', '}');
     }
 
-    public function __construct(ProcessorInterface $processor = null, string $startSep = '---', string $endSep = '---')
+    public function __construct(?ProcessorInterface $processor = null, string $startSep = '---', string $endSep = '---')
     {
         $this->startSep = $startSep;
         $this->endSep = $endSep;

--- a/src/Pug/PugCommentFrontMatter.php
+++ b/src/Pug/PugCommentFrontMatter.php
@@ -29,12 +29,12 @@ final class PugCommentFrontMatter
         // prevent any instantiation
     }
 
-    public static function createWithEndComment(ProcessorInterface $processor = null): FrontMatter
+    public static function createWithEndComment(?ProcessorInterface $processor = null): FrontMatter
     {
         return new FrontMatter($processor ?? new YamlProcessor(), '//-', '//-');
     }
 
-    public static function create(ProcessorInterface $processor = null): FrontMatter
+    public static function create(?ProcessorInterface $processor = null): FrontMatter
     {
         return new FrontMatter($processor ?? new YamlProcessor(), '//-', "\n");
     }

--- a/src/Twig/FrontMatterLoader.php
+++ b/src/Twig/FrontMatterLoader.php
@@ -30,7 +30,7 @@ class FrontMatterLoader implements LoaderInterface
     public function __construct(
         FrontMatterInterface $parser,
         LoaderInterface $loader,
-        DataToTwigConvertor $convertor = null
+        ?DataToTwigConvertor $convertor = null
     )
     {
         $this->loader = $loader;

--- a/src/Twig/TwigCommentFrontMatter.php
+++ b/src/Twig/TwigCommentFrontMatter.php
@@ -29,7 +29,7 @@ final class TwigCommentFrontMatter
         // prevent any instantiation
     }
 
-    public static function create(ProcessorInterface $processor = null): FrontMatter
+    public static function create(?ProcessorInterface $processor = null): FrontMatter
     {
         return new FrontMatter($processor ?? new YamlProcessor(), '{#---', '---#}');
     }


### PR DESCRIPTION
This fixes the following deprecation warnings with PHP 8.4

```
Deprecated: Webuni\FrontMatter\FrontMatter::__construct(): Implicitly marking parameter $processor as nullable is deprecated, the explicit nullable type must be used instead in /vendor/webuni/front-matter/src/FrontMatter.php on line 42

Deprecated: Webuni\FrontMatter\Twig\TwigCommentFrontMatter::create(): Implicitly marking parameter $processor as nullable is deprecated, the explicit nullable type must be used instead in /vendor/webuni/front-matter/src/Twig/TwigCommentFrontMatter.php on line 32

Deprecated: Webuni\FrontMatter\Pug\PugCommentFrontMatter::createWithEndComment(): Implicitly marking parameter $processor as nullable is deprecated, the explicit nullable type must be used instead in /vendor/webuni/front-matter/src/Pug/PugCommentFrontMatter.php on line 32

Deprecated: Webuni\FrontMatter\Pug\PugCommentFrontMatter::create(): Implicitly marking parameter $processor as nullable is deprecated, the explicit nullable type must be used instead in /webuni/front-matter/src/Pug/PugCommentFrontMatter.php on line 37
```
